### PR TITLE
Fix timezone handling in subscription view

### DIFF
--- a/apps/frontend/views.py
+++ b/apps/frontend/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.utils.timezone import datetime
+from django.utils import timezone
 import json
 import os
 from dotenv import load_dotenv
@@ -76,7 +76,7 @@ def submit_and_subscribe(request):
                 })
 
             # Get current time and date
-            current_datetime = datetime.now()
+            current_datetime = timezone.now()
             current_time = current_datetime.strftime("%H:%M:%S")
             current_date = current_datetime.strftime("%Y-%m-%d")
 


### PR DESCRIPTION
## Summary
- fix timezone usage in `submit_and_subscribe` view so times are stored in UTC
- update imports accordingly

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68408b036c1883298142495bc5840064