### PR TITLE
Fix stray closing tag in dashboard template

### DIFF
--- a/apps/dashboard/templates/dashboard.html
+++ b/apps/dashboard/templates/dashboard.html
@@ -196,7 +196,6 @@
         </div>
       </div>
     </div>
-    </main>
 
 <!-- Dropzone JavaScript -->
 <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>


### PR DESCRIPTION
## Summary
- remove an extra `</main>` closing tag from the dashboard HTML template

## Testing
- `./run_tests.sh` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68408fbca71c8329b9223d1d585f4de0