### PR TITLE
Fix template block tags in quiz page

### DIFF
--- a/apps/dashboard/templates/my_quizzes.html
+++ b/apps/dashboard/templates/my_quizzes.html
@@ -22,12 +22,14 @@ Quizzes - SISIMPUR {% endblock %} {% block content %}
             <h3 class="quiz-title">{{ job.document_name }}</h3>
             <span class="quiz-status status-{{ job.status }}">
               {% if job.status == 'pending' %}
-              <i class="ri-time-line"></i> Pending {% elif job.status ==
-              'processing' %} <i class="ri-loader-4-line"></i> Processing {%
-              elif job.status == 'completed' %}
-              <i class="ri-check-line"></i> Completed {% elif job.status ==
-              'failed' %} <i class="ri-error-warning-line"></i> Failed {% endif
-              %}
+                <i class="ri-time-line"></i> Pending
+              {% elif job.status == 'processing' %}
+                <i class="ri-loader-4-line"></i> Processing
+              {% elif job.status == 'completed' %}
+                <i class="ri-check-line"></i> Completed
+              {% elif job.status == 'failed' %}
+                <i class="ri-error-warning-line"></i> Failed
+              {% endif %}
             </span>
           </div>
 


### PR DESCRIPTION
## Summary
- fix invalid block tags in `my_quizzes.html`

## Testing
- `python - <<'EOF'
import django, os
os.environ.setdefault('DJANGO_SETTINGS_MODULE','core.settings')
django.setup()
from django.template import loader
loader.get_template('my_quizzes.html')
print('Template OK')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684095bd50588329a4c803217d4f0f6f